### PR TITLE
Quick items: contiguous same update request

### DIFF
--- a/src/quick/items/qquickitem.cpp
+++ b/src/quick/items/qquickitem.cpp
@@ -5866,7 +5866,6 @@ void QQuickItemPrivate::addToDirtyList()
         if (nextDirtyItem) QQuickItemPrivate::get(nextDirtyItem)->prevDirtyItem = &nextDirtyItem;
         prevDirtyItem = &p->dirtyItemList;
         p->dirtyItemList = q;
-        p->dirtyItem(q);
     }
     Q_ASSERT(prevDirtyItem);
 }


### PR DESCRIPTION
1. Update request always send after  addToDirtyList() called.  
2. It's more clear that we just do 'add' operation in addToDirtyList()