### PR TITLE
qsgtexture: fix debug build with uclibc

### DIFF
--- a/src/quick/scenegraph/util/qsgtexture.cpp
+++ b/src/quick/scenegraph/util/qsgtexture.cpp
@@ -53,7 +53,7 @@
 #endif
 #include <private/qsgmaterialshader_p.h>
 
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID) && defined(__GLIBC__)
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID) && defined(__GLIBC__) && !defined(__UCLIBC__)
 #define CAN_BACKTRACE_EXECINFO
 #endif
 


### PR DESCRIPTION
Debug build of qsgtexture fails on uclibc since version 5.11 and
https://github.com/qt/qtdeclarative/commit/7c507eaac3f848f92f2ebdafe8ded4a064d68351:

scenegraph/util/qsgtexture.cpp:69:22: fatal error: execinfo.h: No such file or directory
 #include <execinfo.h>

Indeed, !defined(__UCLIBC__) has been replaced by defined(__GBLIBC__) to
fix build on musl but as a result, build fails on uclibc because uclibc
also defines __GLIBC__ (and it does not have execinfo like musl)

This error is raised only when building in debug mode because
CAN_BACKTRACE_EXECINFO is undefined if QT_NO_DEBUG is set

So keep defined(__GLIBC__), but put back !defined(__UCLIBC__)

Fixes:
 - http://autobuild.buildroot.org/results/6fce0ce5aea943e097532efbbc8d1e28f41e5866

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>