### PR TITLE
Update and fix qquickstyle.cpp

### DIFF
--- a/src/quickcontrols2/qquickstyle.cpp
+++ b/src/quickcontrols2/qquickstyle.cpp
@@ -386,7 +386,7 @@ bool QQuickStylePrivate::isDarkSystemTheme()
 {
     const static bool dark = [](){
         if (const QPlatformTheme *theme = QGuiApplicationPrivate::platformTheme())
-            return theme->appearance() == QPlatformTheme::Appearance::Dark;
+            return theme->appearance() == Qt::Appearance::Dark;
         return false;
     }();
     return dark;


### PR DESCRIPTION
At build time the QPlatformTheme project does not have an Appearance member and this member is for the Qt namespace. As a result, line 391 was changed from QPlatformTheme to Qt.